### PR TITLE
编译指令bug修改

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ xelatex mt-book-xelatex
 biber mt-book-xelatex
 makeindex mt-book-xelatex
 xelatex mt-book-xelatex
+xelatex mt-book-xelatex
 ```
 
 在编译中可能会遇到内存不足的问题，可以通过以下方式解决：


### PR DESCRIPTION
原本在biber和makeindex后只编译一次xelatex，会造成部分页面文字内容显示不全，再增加一次xelatex编译，即可解决问题